### PR TITLE
[IE CLDNN] Detection output : fix error in padded confidence

### DIFF
--- a/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/detection_output/detection_output_kernel_ref.cpp
+++ b/inference-engine/thirdparty/clDNN/kernel_selector/core/actual_kernels/detection_output/detection_output_kernel_ref.cpp
@@ -92,7 +92,11 @@ DetectionOutputKernelRef::DispatchData SetDefault(const detection_output_params&
             dispatchData.gws = {input.Batch().v, num_prior_boxes, 1};
             dispatchData.lws = {1, 1, 1};
         } else {
-            dispatchData.gws = {CeilDiv(num_classes, 4), 256, input.Batch().v};
+            if (detectOutParams.conf_padding_x || detectOutParams.conf_padding_y) {
+                dispatchData.gws = {num_classes, 256, input.Batch().v};
+            } else {
+                dispatchData.gws = {CeilDiv(num_classes, 4), 256, input.Batch().v};
+            }
             dispatchData.lws = {1, 256, 1};
         }
     } else if (idx == 1) {
@@ -186,11 +190,15 @@ KernelsData DetectionOutputKernelRef::GetKernelsData(const Params& params, const
             if (detectOutParams.detectOutParams.decrease_label_id) {
                 cldnnJit.AddConstant(MakeJitConstant("DO_STAGE_" + std::to_string(i) + "_MXNET", "true"));
             } else {
+                if (detectOutParams.detectOutParams.conf_padding_x || detectOutParams.detectOutParams.conf_padding_y) {
+                    cldnnJit.AddConstants({MakeJitConstant("DO_STAGE_" + std::to_string(i) + "_CAFFE", "true")});
+                } else {
+                    cldnnJit.AddConstants({MakeJitConstant("DO_STAGE_" + std::to_string(i) + "_CAFFE_OPT", "true")});
+                }
                 size_t num_bit_mask = CeilDiv(num_prior_boxes, 8);
                 size_t num_score_per_item = RoundUp(CeilDiv(num_prior_boxes, 256), 8);
                 size_t num_score_block = CeilDiv(num_prior_boxes, num_score_per_item);
-                cldnnJit.AddConstants({MakeJitConstant("DO_STAGE_" + std::to_string(i) + "_CAFFE", "true"),
-                                       MakeJitConstant("NUM_BIT_MASK", num_bit_mask),
+                cldnnJit.AddConstants({MakeJitConstant("NUM_BIT_MASK", num_bit_mask),
                                        MakeJitConstant("NUM_PRIORS_PER_ITEM", num_score_per_item),
                                        MakeJitConstant("NUM_PRIOR_BLOCKS", num_score_block)});
             }


### PR DESCRIPTION
### Details:
- Fixed stage 0 not to use optimized  caffe kernel when confidence is padded. 
- (Because if confidence is padded, they cannot be read at a time) 

### Tickets:
 - *ticket-id*
